### PR TITLE
Application env honors `rails_env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 # Changelog
 
 ### master
+- enable setting unicorn app environment with `rails_env` option.
+  If `rails_env` is not set, `stage` option is used as until now. (@bruno-)
 
 ### v2.1.0, 2014-08-05
 - add `nginx_location` option that specifies nginx installation dir
   (@jordanyaker)
+
 ### v2.0.0, 2014-04-11
 - all the work is moved to the `setup` task
+
 ### v1.0.2, 2014-03-30
 - add `sudo_upload!` helper method for easier uploads
 - improve the way how templates are handled
+
 ### v1.0.1, 2014-03-30
 - refactor all unicorn and nginx paths to separate modules
 - speed up `nginx:setup_ssl` task
 - small README update
+
 ### v1.0.0, 2014-03-29
 - @bruno- all the v1.0.0 features

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Path for unicorn config file.
 - `set :unicorn_workers, 2`<br/>
 Number of unicorn workers.
 
+- `set :unicorn_app_env`<br/>
+Set to the value of `rails_env` (for compatibility with
+[capistrano-rails gem](https://github.com/capistrano/rails) or `stage` option.
+
 ### How it works
 
 Here's what happens when you run `$ bundle exec cap production setup`:

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -13,6 +13,7 @@ namespace :load do
     set :unicorn_workers, 2
     set :unicorn_tcp_listen_port, 8080
     set :unicorn_use_tcp, -> { roles(:app).count > 1}  # use tcp if there are multiple app nodes
+    set :unicorn_app_env, -> { fetch(:rails_env) || fetch(:stage) }
     # set :unicorn_user # default set in `unicorn:defaults` task
 
     set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids')

--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
@@ -16,7 +16,7 @@ APP_ROOT=<%= current_path %>
 PID=<%= fetch(:unicorn_pid) %>
 
 AS_USER=<%= fetch(:unicorn_user) %>
-CMD="export HOME; true "${HOME:=$(getent passwd "$AS_USER" | cut -d: -f6;)}" ; cd $APP_ROOT && <%= bundle_unicorn("-D -c", fetch(:unicorn_config), "-E", fetch(:stage)) %>"
+CMD="export HOME; true "${HOME:=$(getent passwd "$AS_USER" | cut -d: -f6;)}" ; cd $APP_ROOT && <%= bundle_unicorn("-D -c", fetch(:unicorn_config), "-E", fetch(:unicorn_app_env)) %>"
 
 set -u
 


### PR DESCRIPTION
If capistrano-rails gem is used, we honor the `rails_env` option required by
that plugin.

Fallback to `stage` option. This solution is backwards compatible.

This pull request is equivalent to
[this](https://github.com/capistrano-plugins/capistrano-postgresql/pull/9)
PR for capistrano-postgres.
