### PR TITLE
Update when TCP is used automatically for nginx and unicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### master
+- setup nginx and unicorn to use TCP if web and app roles are using different
+  servers
 
 ### v3.0.0, 2014-10-05
 - enable setting unicorn app environment with `rails_env` option.

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -12,7 +12,7 @@ namespace :load do
     set :unicorn_config, -> { unicorn_default_config_file }
     set :unicorn_workers, 2
     set :unicorn_tcp_listen_port, 8080
-    set :unicorn_use_tcp, -> { roles(:app).count > 1}  # use tcp if there are multiple app nodes
+    set :unicorn_use_tcp, -> { roles(:app, :web).count > 1 } # use tcp if web and app nodes are on different servers
     set :unicorn_app_env, -> { fetch(:rails_env) || fetch(:stage) }
     # set :unicorn_user # default set in `unicorn:defaults` task
 


### PR DESCRIPTION
This update covers the situation when there's only 1 app + 1 web node.
