### PR TITLE
Include server_name in SSL server config

### DIFF
--- a/lib/generators/capistrano/unicorn_nginx/templates/nginx_conf.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/nginx_conf.erb
@@ -11,6 +11,7 @@ upstream unicorn_<%= fetch(:nginx_config_name) %> {
 <% if fetch(:nginx_use_ssl) %>
 server {
   listen 80;
+  server_name <%= fetch(:nginx_server_name) %>;
   rewrite ^(.*) https://$host$1 permanent;
 }
 <% end %>


### PR DESCRIPTION
Without this, the non-SSL request defaults to the first nginx/vhost configuration with "listen:80"
