### PR TITLE
Added functionality for client SSL certificates to be passed to Rails

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -13,6 +13,8 @@ namespace :load do
     # ssl options
     set :nginx_location, '/etc/nginx'
     set :nginx_use_ssl, false
+    # if true, passes the SSL client certificate to the application server for consumption in Ruby code
+    set :nginx_pass_ssl_client_cert, false
     set :nginx_ssl_cert, -> { nginx_default_ssl_cert_file_name }
     set :nginx_ssl_cert_key, -> { nginx_default_ssl_cert_key_file_name }
     set :nginx_upload_local_cert, true

--- a/lib/capistrano/unicorn_nginx/helpers.rb
+++ b/lib/capistrano/unicorn_nginx/helpers.rb
@@ -8,13 +8,21 @@ module Capistrano
         SSHKit::Command.new(:bundle, :exec, :unicorn, args).to_command
       end
 
-      def template(template_name)
+      # renders the ERB template specified by template_name to string. Use the locals variable to pass locals to the
+      # ERB template
+      def template_to_s(template_name, locals = {})
         config_file = "#{fetch(:templates_path)}/#{template_name}"
         # if no customized file, proceed with default
         unless File.exists?(config_file)
           config_file = File.join(File.dirname(__FILE__), "../../generators/capistrano/unicorn_nginx/templates/#{template_name}")
         end
-        StringIO.new(ERB.new(File.read(config_file)).result(binding))
+
+        ERB.new(File.read(config_file)).result(ERBNamespace.new(locals).get_binding)
+      end
+
+      # renders the ERB template specified by template_name to a StringIO buffer
+      def template(template_name, locals = {})
+        StringIO.new(template_to_s(template_name, locals))
       end
 
       def file_exists?(path)
@@ -33,6 +41,18 @@ module Capistrano
         sudo :mv, tmp_file, to_dir
       end
 
+      # Helper class to pass local variables to an ERB template
+      class ERBNamespace
+        def initialize(hash)
+          hash.each do |key, value|
+            singleton_class.send(:define_method, key) { value }
+          end
+        end
+
+        def get_binding
+          binding
+        end
+      end
     end
   end
 end

--- a/lib/generators/capistrano/unicorn_nginx/templates/_default_server_directive.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/_default_server_directive.erb
@@ -1,0 +1,83 @@
+<% if fetch(:nginx_use_ssl) && nginx_pass_ssl_client_cert %>
+# source: http://forum.nginx.org/read.php?2,236546,236596
+map $ssl_client_raw_cert $a {
+    "~^(-.*-\n)(?<1st>[^\n]+)\n((?<b>[^\n]+)\n)?((?<c>[^\n]+)\n)?((?<d>[^\n]+)\n)?((?<e>[^\n]+)\n)?((?<f>[^\n]+)\n)?((?<g>[^\n]+)\n)?((?<h>[^\n]+)\n)?((?<i>[^\n]+)\n)?((?<j>[^\n]+)\n)?((?<k>[^\n]+)\n)?((?<l>[^\n]+)\n)?((?<m>[^\n]+)\n)?((?<n>[^\n]+)\n)?((?<o>[^\n]+)\n)?((?<p>[^\n]+)\n)?((?<q>[^\n]+)\n)?((?<r>[^\n]+)\n)?((?<s>[^\n]+)\n)?((?<t>[^\n]+)\n)?((?<v>[^\n]+)\n)?((?<u>[^\n]+)\n)?((?<w>[^\n]+)\n)?((?<x>[^\n]+)\n)?((?<y>[^\n]+)\n)?((?<z>[^\n]+)\n)?(-.*-)$" $1st;
+}
+<% end %>
+
+server {
+<% if fetch(:nginx_use_ssl) %>
+    <% if fetch(:nginx_use_spdy) %>
+    listen <%= ssl_port %> spdy;
+    <% else %>
+    listen <%= ssl_port %>;
+    <% end %>
+    ssl on;
+    ssl_certificate <%= nginx_ssl_cert_file %>;
+    ssl_certificate_key <%= nginx_ssl_cert_key_file %>;
+<% else %>
+    listen 80;
+<% end %>
+
+<% if fetch(:nginx_use_ssl) && nginx_pass_ssl_client_cert %>
+    ssl_verify_client optional_no_ca;
+<% end %>
+
+    client_max_body_size 4G;
+    keepalive_timeout 10;
+
+    error_page 500 502 504 /500.html;
+    error_page 503 @503;
+
+    server_name <%= fetch(:nginx_server_name) %>;
+    root <%= current_path %>/public;
+    try_files $uri/index.html $uri @unicorn_<%= fetch(:nginx_config_name) %>;
+
+    location @unicorn_<%= fetch(:nginx_config_name) %> {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        <% if fetch(:nginx_use_ssl) %>
+        proxy_set_header X-Forwarded-Proto https;
+        <% end %>
+        <% if fetch(:nginx_use_ssl) && nginx_pass_ssl_client_cert %>
+        # source: http://forum.nginx.org/read.php?2,236546,236596
+        proxy_set_header X-Client-Cert $a$b$c$d$e$f$g$h$i$j$k$l$m$n$o$p$q$r$s$t$v$u$w$x$y$z;
+        <% end %>
+
+        proxy_pass http://unicorn_<%= fetch(:nginx_config_name) %>;
+        # limit_req zone=one;
+        access_log <%= nginx_access_log_file %>;
+        error_log <%= nginx_error_log_file %>;
+    }
+
+    location ^~ /assets/ {
+        gzip_static on;
+        expires max;
+        add_header Cache-Control public;
+    }
+
+    location = /50x.html {
+        root html;
+    }
+
+    location = /404.html {
+        root html;
+    }
+
+    location @503 {
+        error_page 405 = /system/maintenance.html;
+        if (-f $document_root/system/maintenance.html) {
+            rewrite ^(.*)$ /system/maintenance.html break;
+        }
+        rewrite ^(.*)$ /503.html break;
+    }
+
+    if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ){
+        return 405;
+    }
+
+    if (-f $document_root/system/maintenance.html) {
+        return 503;
+    }
+}

--- a/lib/generators/capistrano/unicorn_nginx/templates/nginx_conf.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/nginx_conf.erb
@@ -16,71 +16,10 @@ server {
 }
 <% end %>
 
-server {
-<% if fetch(:nginx_use_ssl) %>
-  <% if fetch(:nginx_use_spdy) %>
-  listen 443 spdy;
-  <% else %>
-  listen 443;
-  <% end %>
-  ssl on;
-  ssl_certificate <%= nginx_ssl_cert_file %>;
-  ssl_certificate_key <%= nginx_ssl_cert_key_file %>;
-<% else %>
-  listen 80;
+<% # render the default server directive. If SSL is enabled, port 443 is used %>
+<%= template_to_s("_default_server_directive.erb", ssl_port: 443, nginx_pass_ssl_client_cert: false).to_s %>
+
+<% if fetch(:nginx_pass_ssl_client_cert) %>
+<% # render the server directive with SSL client certificate authentication enabled on port 444 %>
+<%= template_to_s("_default_server_directive.erb", ssl_port: 444, nginx_pass_ssl_client_cert: true).to_s %>
 <% end %>
-
-  client_max_body_size 4G;
-  keepalive_timeout 10;
-
-  error_page 500 502 504 /500.html;
-  error_page 503 @503;
-
-  server_name <%= fetch(:nginx_server_name) %>;
-  root <%= current_path %>/public;
-  try_files $uri/index.html $uri @unicorn_<%= fetch(:nginx_config_name) %>;
-
-  location @unicorn_<%= fetch(:nginx_config_name) %> {
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
-    proxy_redirect off;
-<% if fetch(:nginx_use_ssl) %>
-    proxy_set_header X-Forwarded-Proto https;
-<% end %>
-    proxy_pass http://unicorn_<%= fetch(:nginx_config_name) %>;
-    # limit_req zone=one;
-    access_log <%= nginx_access_log_file %>;
-    error_log <%= nginx_error_log_file %>;
-  }
-
-  location ^~ /assets/ {
-    gzip_static on;
-    expires max;
-    add_header Cache-Control public;
-  }
-
-  location = /50x.html {
-    root html;
-  }
-
-  location = /404.html {
-    root html;
-  }
-
-  location @503 {
-    error_page 405 = /system/maintenance.html;
-    if (-f $document_root/system/maintenance.html) {
-      rewrite ^(.*)$ /system/maintenance.html break;
-    }
-    rewrite ^(.*)$ /503.html break;
-  }
-
-  if ($request_method !~ ^(GET|HEAD|PUT|PATCH|POST|DELETE|OPTIONS)$ ){
-    return 405;
-  }
-
-  if (-f $document_root/system/maintenance.html) {
-    return 503;
-  }
-
-}


### PR DESCRIPTION
This commit makes it possible to perform client authentication via SSL certificates. The
client provides an SSL certificate which is passed to Rails. Based on custom computation,
controllers can decide whether to grant access.

This commit changes the following:

- It adds a new option `nginx_pass_ssl_client_cert`. If true, nginx is configured to pass
  the SSL certificate of the client to Rails. Rails receives these as
  `request.headers['X-Client-Cert']` or `request.headers['rack.session']['X-Client-Cert']`
- It enables local variables to be passed via the `template` method.
- If `nginx_pass_ssl_client_cert` is true, an additional server directive is generated for
  port 444, which accepts SSL client certificate authentication.


If this pull request is accepted. I will add additional documentation and information on how to create controllers for validating the SSL certificate of the client. The main benefit of passing SSL certificates to Rails, instead of configuring these in nginx, is that no nginx configuration has to be changed when adding or revoking SSL certificates. Moreover, different controllers can allow different SSL sets of certificates, without creating additional server or location directives in nginx conf.