### PR TITLE
Unicorn nginx task opts

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -9,6 +9,10 @@ namespace :load do
     set :templates_path, 'config/deploy/templates'
     set :nginx_config_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
     set :nginx_pid, nginx_default_pid_file
+    # if true setup nginx config 
+    set :setup_nginx, true
+    # if true reload nginx on deploy
+    set :nginx_reload, true
     # set :nginx_server_name # default set in the `nginx:defaults` task
     # ssl options
     set :nginx_location, '/etc/nginx'
@@ -37,6 +41,7 @@ namespace :nginx do
 
   desc 'Setup nginx configuration'
   task :setup do
+    next unless fetch(:setup_nginx)
     on roles :web do
       sudo_upload! template('nginx_conf.erb'), nginx_sites_available_file
       sudo :ln, '-fs', nginx_sites_available_file, nginx_sites_enabled_file
@@ -59,6 +64,7 @@ namespace :nginx do
 
   desc 'Reload nginx configuration'
   task :reload do
+    next unless fetch(:nginx_reload)
     on roles :web do
       sudo nginx_service_path, 'reload'
     end

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -17,6 +17,13 @@ namespace :load do
     set :unicorn_use_tcp, -> { roles(:app, :web).count > 1 } # use tcp if web and app nodes are on different servers
     set :unicorn_app_env, -> { fetch(:rails_env) || fetch(:stage) }
     # set :unicorn_user # default set in `unicorn:defaults` task
+    #
+    # if true setup unicorn init 
+    set :setup_unicorn_init, true
+    # if true setup unicorn config
+    set :setup_unicorn_config, true
+    # if true can start, stop, restart unicorn
+    set :manage_unicorn, true
 
     set :unicorn_logrotate_enabled, false # by default, don't use logrotate to rotate unicorn logs
 
@@ -34,6 +41,7 @@ namespace :unicorn do
 
   desc 'Setup Unicorn initializer'
   task :setup_initializer do
+    next unless fetch(:setup_unicorn_inti)
     on roles :app do
       sudo_upload! template('unicorn_init.erb'), unicorn_initd_file
       execute :chmod, '+x', unicorn_initd_file
@@ -43,6 +51,7 @@ namespace :unicorn do
 
   desc 'Setup Unicorn app configuration'
   task :setup_app_config do
+    next unless fetch(:setup_unicorn_config)
     on roles :app do
       execute :mkdir, '-pv', File.dirname(fetch(:unicorn_config))
       upload! template('unicorn.rb.erb'), fetch(:unicorn_config)
@@ -61,6 +70,7 @@ namespace :unicorn do
   %w[start stop restart].each do |command|
     desc "#{command} unicorn"
     task command do
+      next unless fetch(:manage_unicorn)
       on roles :app do
         execute :service, fetch(:unicorn_service), command
       end


### PR DESCRIPTION
Created some options to allow the user to control what tasks are run when `$ bundle exec cap production setup` and `$ bundle exec cap production deploy`. With these options if the user for example wants to run all the tasks in this plugin except for having it create the nginx config they can set the option `set :setup_nginx, false` to skip creating the nginx config. 