### PR TITLE
unicorn commands are use 'sudo' if Debian?

### DIFF
--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -62,7 +62,12 @@ namespace :unicorn do
     desc "#{command} unicorn"
     task command do
       on roles :app do
-        execute :service, fetch(:unicorn_service), command
+        uname = capture(:uname, '-a')
+        if /Debian \d.+ GNU\/Linux$/ =~ uname
+          sudo :service, fetch(:unicorn_service), command
+        else
+          execute :service, fetch(:unicorn_service), command
+        end
       end
     end
   end


### PR DESCRIPTION
issues #8 #31 #53 
already have a PR #37 

but this version is upgraded. point is detect 'Debian' and then use `sudo`

TESTED
- local: Macbook
- remote: Debian

TODO: 
- test with other linux
- enhance 'detect Debian' regexp