### PR TITLE
Through setting to support CentOS6.

### DIFF
--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -18,6 +18,8 @@ namespace :load do
     set :unicorn_use_tcp, -> { roles(:app, :web).count > 1 } # use tcp if web and app nodes are on different servers
     set :unicorn_app_env, -> { fetch(:rails_env) || fetch(:stage) }
     # set :unicorn_user # default set in `unicorn:defaults` task
+    
+    # set :unicorn_target_server_os, 'centos6'
 
     set :unicorn_logrotate_enabled, false # by default, don't use logrotate to rotate unicorn logs
 
@@ -38,7 +40,11 @@ namespace :unicorn do
     on roles :app do
       sudo_upload! template('unicorn_init.erb'), unicorn_initd_file
       execute :chmod, '+x', unicorn_initd_file
-      sudo 'update-rc.d', '-f', fetch(:unicorn_service), 'defaults'
+      if fetch(:unicorn_target_server_os) == 'centos6'
+        sudo 'chkconfig', '--add', fetch(:unicorn_service)
+      else
+        sudo 'update-rc.d', '-f', fetch(:unicorn_service), 'defaults'
+      end
     end
   end
 
@@ -63,7 +69,11 @@ namespace :unicorn do
     desc "#{command} unicorn"
     task command do
       on roles :app do
-        execute :service, fetch(:unicorn_service), command
+        if fetch(:unicorn_target_server_os) == 'centos6'
+          sudo :service, fetch(:unicorn_service), command
+        else
+          execute :service, fetch(:unicorn_service), command
+        end
       end
     end
   end


### PR DESCRIPTION
## Adjust the environment with nginx

use root permission or sudo

```
mkdir -pv /etc/nginx/sites-available
mkdir -pv /etc/nginx/sites-enabled
touch /etc/nginx/conf.d/include-sites-enabled.conf
echo 'include /etc/nginx/sites-enabled/*;' > /etc/nginx/conf.d/include-sites-enabled.conf
```

## setup unicorn  to support centos

add a line set to /config/deploy/production.rb

```
set :unicorn_target_server_os, 'centos6'
```