### PR TITLE
Allow customizing paths for SSL certificate and key

### DIFF
--- a/lib/capistrano/dsl/nginx_paths.rb
+++ b/lib/capistrano/dsl/nginx_paths.rb
@@ -27,12 +27,20 @@ module Capistrano
         "#{fetch(:nginx_server_name)}.key"
       end
 
+      def nginx_default_ssl_cert_file_path
+        "/etc/ssl/certs/"
+      end
+
+      def nginx_default_ssl_cert_key_file_path
+        "/etc/ssl/private/"
+      end
+
       def nginx_ssl_cert_file
-        "/etc/ssl/certs/#{fetch(:nginx_ssl_cert)}"
+        "#{fetch(:nginx_ssl_cert_path)}#{fetch(:nginx_ssl_cert)}"
       end
 
       def nginx_ssl_cert_key_file
-        "/etc/ssl/private/#{fetch(:nginx_ssl_cert_key)}"
+        "#{fetch(:nginx_ssl_cert_key_path)}#{fetch(:nginx_ssl_cert_key)}"
       end
 
       # log files

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -18,6 +18,8 @@ namespace :load do
     set :nginx_pass_ssl_client_cert, false
     set :nginx_ssl_cert, -> { nginx_default_ssl_cert_file_name }
     set :nginx_ssl_cert_key, -> { nginx_default_ssl_cert_key_file_name }
+    set :nginx_ssl_cert_path, -> { nginx_default_ssl_cert_file_path }
+    set :nginx_ssl_cert_key_path, -> { nginx_default_ssl_cert_key_file_path }
     set :nginx_upload_local_cert, true
     set :nginx_ssl_cert_local_path, -> { ask(:nginx_ssl_cert_local_path, 'Local path to ssl certificate: ') }
     set :nginx_ssl_cert_key_local_path, -> { ask(:nginx_ssl_cert_key_local_path, 'Local path to ssl certificate key: ') }


### PR DESCRIPTION
This change allows customizing the paths where the SSL certificate and key are written. 

The use case for me is that I'm deploying to a server that is shared by several applications, and the low-privilege user running this deployment does not have read access to the /etc/ssl/private/ directory. This causes deploy:setup to fail because it cannot verify whether the key is present.