### PR TITLE
Use unicorn reload instead of restart

### DIFF
--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -59,7 +59,7 @@ namespace :unicorn do
     end
   end
 
-  %w[start stop restart].each do |command|
+  %w[start stop restart reload].each do |command|
     desc "#{command} unicorn"
     task command do
       on roles :app do
@@ -74,7 +74,7 @@ namespace :unicorn do
 end
 
 namespace :deploy do
-  after :publishing, 'unicorn:restart'
+  after :publishing, 'unicorn:reload'
 end
 
 desc 'Server setup tasks'


### PR DESCRIPTION
In case of systemd the restart command does not work the way it should. It is running the restart job of the service unit instead of running the restart function of the System V init script.

My experience on Debian 8.1 and systemd was that every other unit restart did not started up a new master process, only let the old master and workers die.

The solution I choose is running reload instead of restart since reload executes the same function as restart in the System V script and systemd units does not have a reload job so in case of systemd it will fall back to the System V reload call.