### PR TITLE
modified 'nginx_service_path' to configurable

### DIFF
--- a/lib/capistrano/dsl/nginx_paths.rb
+++ b/lib/capistrano/dsl/nginx_paths.rb
@@ -11,7 +11,7 @@ module Capistrano
       end
 
       def nginx_service_path
-        '/etc/init.d/nginx'
+        "#{fetch(:nginx_service_path)}"
       end
 
       def nginx_default_pid_file

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -9,6 +9,7 @@ namespace :load do
     set :templates_path, 'config/deploy/templates'
     set :nginx_config_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
     set :nginx_pid, nginx_default_pid_file
+    set :nginx_service_path, '/etc/init.d/nginx'
     # set :nginx_server_name # default set in the `nginx:defaults` task
     # ssl options
     set :nginx_location, '/etc/nginx'


### PR DESCRIPTION
solve issue https://github.com/capistrano-plugins/capistrano-unicorn-nginx/issues/84 
This change enable nginx reload command.
Example:
  Ubuntu or Debian
    `sudo /etc/init.d/nginx reload`
  CentOS7
    `sudo service nginx reload`
    it needs to write "set :nginx_service_path, 'service nginx" to deploy config.
