### PR TITLE
Fix unicorn:restart

### DIFF
--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -59,11 +59,22 @@ namespace :unicorn do
     end
   end
 
-  %w[start stop restart reload].each do |command|
+  %w[start stop reload upgrade].each do |command|
     desc "#{command} unicorn"
     task command do
       on roles :app do
         sudo 'service', fetch(:unicorn_service), command
+      end
+    end
+  end
+
+  desc 'restart unicorn'
+  task 'restart' do
+    on roles :app do
+      if test "[ -f #{fetch(:unicorn_pid)} ]"
+        sudo 'service', fetch(:unicorn_service), 'upgrade'
+      else
+        sudo 'service', fetch(:unicorn_service), 'start'
       end
     end
   end
@@ -74,7 +85,7 @@ namespace :unicorn do
 end
 
 namespace :deploy do
-  after :publishing, 'unicorn:reload'
+  after :publishing, 'unicorn:restart'
 end
 
 desc 'Server setup tasks'

--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn.rb.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn.rb.erb
@@ -28,7 +28,8 @@ before_fork do |server, worker|
   old_pid = "#{server.config[:pid]}.oldbin"
   if File.exists?(old_pid) && server.pid != old_pid
     begin
-      Process.kill("QUIT", File.read(old_pid).to_i)
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
     rescue Errno::ENOENT, Errno::ESRCH
       # someone else did our job for us
     end

--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
@@ -53,7 +53,7 @@ force-stop)
   echo >&2 "Not running"
   ;;
 restart|reload)
-  sig USR2 && echo reloaded OK && exit 0
+  sig HUP && echo reloaded OK && exit 0
   echo >&2 "Couldn't reload, starting '$CMD' instead"
   run "$CMD"
   ;;


### PR DESCRIPTION
Unicorn restart was not working (you needed to do it twice).
This was happening because Unicorn is configured with `app_preload=true`, and we need to send a QUIT signal after the USR2 signal. See [Unicorn Signal documentation](https://unicorn.bogomips.org/SIGNALS.html).

I know that in the `before_fork` block of `unicorn.conf` the code tries to send the mentioned QUIT signal, but in may case it was not working.

This problem seems to be happening to more people as well https://github.com/capistrano-plugins/capistrano-unicorn-nginx/issues/59 and https://github.com/capistrano-plugins/capistrano-unicorn-nginx/issues/62.
