### PR TITLE
Fix unicorn_init script header to avoid problems with rcconf

### DIFF
--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 ### BEGIN INIT INFO
-# Provides: unicorn
+# Provides: unicorn_<%= fetch(:application) %>
 # Required-Start: $remote_fs $syslog
 # Required-Stop: $remote_fs $syslog
 # Default-Start: 2 3 4 5


### PR DESCRIPTION
When you have multiple applications on the same server and multiple unicorn_init scripts for them, the rcconf (Debian Runlevel configuration tool) raising an error: "service unicorn already provided!". To avoid this it's lets add e.g. application name to service name.