### PR TITLE
Added configuration for nginx log location and level

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -26,6 +26,9 @@ namespace :load do
     set :nginx_ssl_cert_key_local_path, -> { ask(:nginx_ssl_cert_key_local_path, 'Local path to ssl certificate key: ') }
     set :nginx_fail_timeout, 0 # see http://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout
     set :nginx_read_timeout, nil
+    
+    set :nginx_log_path, nil
+    set :nginx_log_level, 'debug'
 
     set :linked_dirs, fetch(:linked_dirs, []).push('log')
   end

--- a/lib/generators/capistrano/unicorn_nginx/templates/_default_server_directive.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/_default_server_directive.erb
@@ -43,6 +43,12 @@ server {
     error_page 500 502 504 /500.html;
     error_page 503 @503;
 
+<% if fetch(:nginx_log_path) -%>
+  access_log <%= fetch(:nginx_log_path) %>/nginx_access.log combined
+  error_log <%= fetch(:nginx_log_path) %>/nginx_error.log <%= fetch(:nginx_log_level) %>
+<% end -%>
+
+
     server_name <%= fetch(:nginx_server_name) %>;
     root <%= current_path %>/public;
     try_files $uri/index.html $uri @unicorn_<%= fetch(:nginx_config_name) %>;


### PR DESCRIPTION
Added `:nginx_log_path` and `:nginx_log_level` configuration to properly set nginx logging. I usually store the nginx logs with all the others in the applications log folder, so might be usefull.  