### PR TITLE
add systemd support

### DIFF
--- a/lib/capistrano/dsl/unicorn_paths.rb
+++ b/lib/capistrano/dsl/unicorn_paths.rb
@@ -6,6 +6,10 @@ module Capistrano
         "/etc/init.d/#{fetch(:unicorn_service)}"
       end
 
+      def unicorn_systemd_file
+        "/etc/systemd/system/#{fetch(:unicorn_service)}.service"
+      end
+
       def unicorn_default_config_file
         shared_path.join('config/unicorn.rb')
       end

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -6,6 +6,7 @@ include Capistrano::DSL::NginxPaths
 
 namespace :load do
   task :defaults do
+    set :init_system, :sysv
     set :templates_path, 'config/deploy/templates'
     set :nginx_config_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
     set :nginx_pid, nginx_default_pid_file
@@ -65,7 +66,13 @@ namespace :nginx do
   desc 'Reload nginx configuration'
   task :reload do
     on roles :web do
-      sudo nginx_service_path, 'reload'
+      case fetch(:init_system)
+      when :sysv
+        sudo nginx_service_path, 'reload'
+      when :systemd
+        sudo "systemctl", "start", "nginx"
+        sudo "systemctl", "reload", "nginx"
+      end
     end
   end
 

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -42,7 +42,7 @@ namespace :unicorn do
         execute :chmod, '+x', unicorn_initd_file
         sudo 'update-rc.d', '-f', fetch(:unicorn_service), 'defaults'
       when :systemd
-        sudo_upload! template('unicorn_service.erb'), fetch(:unicorn_service)
+        sudo_upload! template('unicorn_service.erb'), unicorn_systemd_file
         sudo 'systemctl', 'daemon-reload'
       end
     end

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -36,9 +36,15 @@ namespace :unicorn do
   desc 'Setup Unicorn initializer'
   task :setup_initializer do
     on roles :app do
-      sudo_upload! template('unicorn_init.erb'), unicorn_initd_file
-      execute :chmod, '+x', unicorn_initd_file
-      sudo 'update-rc.d', '-f', fetch(:unicorn_service), 'defaults'
+      case fetch(:init_system)
+      when :sysv
+        sudo_upload! template('unicorn_init.erb'), unicorn_initd_file
+        execute :chmod, '+x', unicorn_initd_file
+        sudo 'update-rc.d', '-f', fetch(:unicorn_service), 'defaults'
+      when :systemd
+        sudo_upload! template('unicorn_service.erb'), fetch(:unicorn_service)
+        sudo 'systemctl', 'daemon-reload'
+      end
     end
   end
 
@@ -53,9 +59,11 @@ namespace :unicorn do
   desc 'Setup logrotate configuration'
   task :setup_logrotate do
     on roles :app do
-      sudo :mkdir, '-pv', File.dirname(fetch(:unicorn_logrotate_config))
-      sudo_upload! template('unicorn-logrotate.rb.erb'), fetch(:unicorn_logrotate_config)
-      sudo 'chown', 'root:root', fetch(:unicorn_logrotate_config)
+      if fetch(:init_system) == :sysv
+        sudo :mkdir, '-pv', File.dirname(fetch(:unicorn_logrotate_config))
+        sudo_upload! template('unicorn-logrotate.rb.erb'), fetch(:unicorn_logrotate_config)
+        sudo 'chown', 'root:root', fetch(:unicorn_logrotate_config)
+      end
     end
   end
 
@@ -63,7 +71,23 @@ namespace :unicorn do
     desc "#{command} unicorn"
     task command do
       on roles :app do
-        sudo 'service', fetch(:unicorn_service), command
+        case fetch(:init_system)
+        when :sysv
+          sudo 'service', fetch(:unicorn_service), command
+        when :systemd
+          sudo 'systemctl', command, fetch(:unicorn_service)
+        end
+      end
+    end
+  end
+
+  task :run_latest do
+    on roles :app do
+      case fetch(:init_system)
+      when :sysv
+        sudo 'service', fetch(:unicorn_service), "reload"
+      when :systemd
+        sudo 'systemctl', "restart", fetch(:unicorn_service)
       end
     end
   end
@@ -74,7 +98,7 @@ namespace :unicorn do
 end
 
 namespace :deploy do
-  after :publishing, 'unicorn:reload'
+  after :publishing, 'unicorn:run_latest'
 end
 
 desc 'Server setup tasks'

--- a/lib/capistrano/unicorn_nginx/helpers.rb
+++ b/lib/capistrano/unicorn_nginx/helpers.rb
@@ -5,7 +5,7 @@ module Capistrano
     module Helpers
 
       def bundle_unicorn(*args)
-        SSHKit::Command.new(:bundle, :exec, :unicorn, args).to_command
+        SSHKit::Command.new(:bundle, :exec, :unicorn, args)
       end
 
       # renders the ERB template specified by template_name to string. Use the locals variable to pass locals to the

--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
@@ -17,7 +17,7 @@ PID=<%= fetch(:unicorn_pid) %>
 
 AS_USER=<%= fetch(:unicorn_user) %>
 UNICORN_ENV="<%= fetch(:unicorn_env) %>"
-CMD="export HOME; true "${HOME:=$(getent passwd "$AS_USER" | cut -d: -f6;)}" ; cd $APP_ROOT && $UNICORN_ENV <%= bundle_unicorn("-D -c", fetch(:unicorn_config), "-E", fetch(:unicorn_app_env)) %>"
+CMD="export HOME; true "${HOME:=$(getent passwd "$AS_USER" | cut -d: -f6;)}" ; cd $APP_ROOT && $UNICORN_ENV <%= bundle_unicorn("-D -c", fetch(:unicorn_config), "-E", fetch(:unicorn_app_env).to_command) %>"
 
 set -u
 

--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_service.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_service.erb
@@ -1,0 +1,20 @@
+<% command = bundle_unicorn("-D -c", fetch(:unicorn_config), "-E", fetch(:unicorn_app_env)) %>
+[Unit]
+Description=Unicorn Server
+Wants=mysqld.service nginx.service postgresql.service
+After=redis.service mysqld.service postgresql.service
+
+[Service]
+User=<%= fetch(:unicorn_user) %>
+WorkingDirectory=<%= current_path %>
+Environment=RAILS_ENV=<%= fetch(:unicorn_app_env) %>
+<% command.environment_hash.each_pair do |key, value| %>
+  Environment=<%= key %>=<%= value %>
+<% end %>
+SyslogIdentifier=unicorn
+PIDFile=<%= fetch(:unicorn_pid) %>
+
+ExecStart=<%= command.to_s %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This fixes #70 by adding an `:init_system` variable which takes values of either `:sysv` or `:systemd`.

The code should not produce any changes in behaviour when run without setting `:init_system` except that I called publish action for unicorn `run_latest`, so the print will be different.

I'm not sure if that is a change you approve of, however the semantics of systemd are different and we have to be careful to actually start the services. Also supporting the reload action with a signal is apparently very much not recommended(it wouldn't be that hard to do though if we really wanted to).

I see that there are other pull requests like #45 that are having trouble getting merged that do similar tasks. It might make sense to have separate flags for init system, service installer, and service reloader. That seems like it would cover all of the different cases if you combined it with making more of the paths configurable. Then the whole thing could be wrapped up in some presets for common configurations. That way you would have decent support for both common OS's and arbitrary OS's.

This code is tested on my arch system right now. I should be putting it through its paces on ubuntu 16.04 soon and could probably give 14.04 a try at the same time. Seems like we are going to need something to run automated tests on different images though or it is going to be impossible to maintain extensions like this in the future.