### PR TITLE
Don't chown existing certificates

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -56,9 +56,10 @@ namespace :nginx do
       if fetch(:nginx_upload_local_cert)
         sudo_upload! fetch(:nginx_ssl_cert_local_path), nginx_ssl_cert_file
         sudo_upload! fetch(:nginx_ssl_cert_key_local_path), nginx_ssl_cert_key_file
+        
+        sudo :chown, 'root:root', nginx_ssl_cert_file
+        sudo :chown, 'root:root', nginx_ssl_cert_key_file
       end
-      sudo :chown, 'root:root', nginx_ssl_cert_file
-      sudo :chown, 'root:root', nginx_ssl_cert_key_file
     end
   end
 


### PR DESCRIPTION
Certificates that aren't uploaded by Capistrano and therefore already exist shouldn't be touched.