### PR TITLE
Don't kill old master process. Allow unicorn to either upgrade or rev…

### DIFF
--- a/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
+++ b/lib/generators/capistrano/unicorn_nginx/templates/unicorn_init.erb
@@ -27,10 +27,6 @@ sig () {
   test -s "$PID" && kill -$1 `cat $PID`
 }
 
-oldsig () {
-  test -s $OLD_PIN && kill -$1 `cat $OLD_PIN`
-}
-
 run () {
   if [ "$(id -un)" = "$AS_USER" ]; then
     eval $1
@@ -58,8 +54,14 @@ restart|reload)
   run "$CMD"
   ;;
 upgrade)
-  if sig USR2 && sleep 2 && sig 0 && oldsig QUIT
+  current_master=`cat $PID`
+  if sig USR2 && sleep 20 && sig 0
   then
+    if test $current_master -eq `cat $PID`
+    then
+      echo >&2 "Failed to upgrade, reverted to old master. Check stderr log for details"
+      exit 1
+    fi
     n=$TIMEOUT
     while test -s $OLD_PIN && test $n -ge 0
     do


### PR DESCRIPTION
…ert it

The oldsig QUIT instruction no longer seems to be necessary. Sending USR2 to unicorn is enough to spin up the new master and either drop the old master process once the new master starts successfully or roll back to the old master if the new master fails.

The upgrade step also sometimes incorrectly returns a success message when unicorn has not started, or failed to upgrade. Currently it waits two seconds then attempts to send a 0 signal to the PID. This has been updated to wait 20 seconds to give unicorn plenty of time to start, and will also check to see if the PID changed or if it was reset back to the old master, returning a failure message to indicate this.

This may be a breaking change if there are older versions of unicorn/other gems that DO require the oldsig QUIT to be sent, so if you'd prefer this could be implemented as a 'safe_upgrade' command rather than changing the upgrade path.

#114 